### PR TITLE
fix: unit handling

### DIFF
--- a/x/evm/keeper/txutils.go
+++ b/x/evm/keeper/txutils.go
@@ -273,7 +273,10 @@ func (u *TxUtils) ConvertCosmosTxToEthereumTx(ctx context.Context, sdkTx sdk.Tx)
 
 		to = &contractAddr
 		input = data
-		value = types.FromEthersUnit(decimals, callMsg.Value.BigInt())
+		// When ethereum tx is converted into cosmos tx by ConvertEthereumTxToCosmosTx,
+		// the value is converted to cosmos fee unit from wei.
+		// So we need to convert it back to wei to get original ethereum tx and verify signature.
+		value = types.ToEthersUint(decimals, callMsg.Value.BigInt())
 	case "/minievm.evm.v1.MsgCreate":
 		createMsg := msg.(*types.MsgCreate)
 		data, err := hexutil.Decode(createMsg.Code)
@@ -283,7 +286,8 @@ func (u *TxUtils) ConvertCosmosTxToEthereumTx(ctx context.Context, sdkTx sdk.Tx)
 
 		to = nil
 		input = data
-		value = types.FromEthersUnit(decimals, createMsg.Value.BigInt())
+		// Same as above (MsgCall)
+		value = types.ToEthersUint(decimals, createMsg.Value.BigInt())
 	case "/minievm.evm.v1.MsgCreate2":
 		// create2 is not supported
 		return nil, nil, nil

--- a/x/evm/keeper/txutils_test.go
+++ b/x/evm/keeper/txutils_test.go
@@ -106,7 +106,7 @@ func Test_DynamicFeeTxConversion(t *testing.T) {
 	// Convert back to ethereum tx
 	ethTx2, _, err := keeper.NewTxUtils(&input.EVMKeeper).ConvertCosmosTxToEthereumTx(ctx, sdkTx)
 	require.NoError(t, err)
-	require.Equal(t, signedTx.Data(), ethTx2.Data())
+	EqualEthTransaction(t, signedTx, ethTx2)
 }
 
 func Test_LegacyTxConversion(t *testing.T) {
@@ -190,5 +190,17 @@ func Test_LegacyTxConversion(t *testing.T) {
 	// Convert back to ethereum tx
 	ethTx2, _, err := keeper.NewTxUtils(&input.EVMKeeper).ConvertCosmosTxToEthereumTx(ctx, sdkTx)
 	require.NoError(t, err)
-	require.Equal(t, signedTx.Data(), ethTx2.Data())
+	EqualEthTransaction(t, signedTx, ethTx2)
+}
+
+func EqualEthTransaction(t *testing.T, expected, actual *coretypes.Transaction) {
+	require.Equal(t, expected.ChainId(), actual.ChainId())
+	require.Equal(t, expected.Nonce(), actual.Nonce())
+	require.Equal(t, expected.GasTipCap(), actual.GasTipCap())
+	require.Equal(t, expected.GasFeeCap(), actual.GasFeeCap())
+	require.Equal(t, expected.Gas(), actual.Gas())
+	require.Equal(t, expected.To(), actual.To())
+	require.Equal(t, expected.Data(), actual.Data())
+	require.Equal(t, expected.Value(), actual.Value())
+	require.Equal(t, expected.Type(), actual.Type())
 }


### PR DESCRIPTION
**Problem**
- When converting Cosmos tx to Ethereum tx, the `value` field is not converted properly, resulting in a discrepancy from the original Ethereum tx.
- Due to this issue, the recovery of the sender from the original Ethereum signature fails, resulting in an incorrect sender (error occurs at the line below).

```go
func verifySignature(
	ctx context.Context,
	pubKey cryptotypes.PubKey,
	signerData txsigning.SignerData,
	signatureData signing.SignatureData,
	handler *txsigning.HandlerMap,
	txData txsigning.TxData,
	// required to verify EVM signatures
	ek *evmkeeper.Keeper,
	tx sdk.Tx,
) error {
    // ...
    sender, err := signer.Sender(ethTx)
    // ...
    if expectedSender == nil || *expectedSender != sender {
        return errorsmod.Wrapf(sdkerrors.ErrorInvalidSigner, "expected sender %s, got %s", expectedSender, sender)
    }
    // ...
}
```

**Fix**
- Use `ToEthersUint` for converting the `value` field in Cosmos tx to Ethereum tx.

**Description**
- When an Ethereum tx is converted into a Cosmos tx using `ConvertEthereumTxToCosmosTx`, the `value` is converted from wei to a unit of mapped erc20's decimal (default is `0`).
- To revert the Cosmos tx back to the original Ethereum tx, the `value` must be converted back to wei to match the original Ethereum tx.

**Proof of Work**
1. Run the updated test code on the previous code base to observe the problem.
2. Apply this patch and run the updated test code again to verify the fix.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
initia user experience or initia developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of initia, if possible.
-->

<!--
Initia has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
