### PR TITLE
make json-rpc public by default

### DIFF
--- a/jsonrpc/config/config.go
+++ b/jsonrpc/config/config.go
@@ -26,7 +26,7 @@ const (
 	// DefaultBlockRangeCap is the default max block range allowed for `eth_getLogs` query.
 	DefaultBlockRangeCap = 100
 	// DefaultAddress defines the default HTTP server to listen on.
-	DefaultAddress = "127.0.0.1:8545"
+	DefaultAddress = "0.0.0.0:8545"
 	// DefaultFilterCap
 	DefaultFilterCap int32 = 200
 )


### PR DESCRIPTION
like lcd and rpc, making json-rpc public sounds reasonable to me.
if it is weird or dangerous, please feel free to close this pr :) 