### PR TITLE
Implement CI/CD workflows for Initia binary builds

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -1,0 +1,19 @@
+name: Build and Upload to releases
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-linux-amd64:
+    uses: ./.github/workflows/build-linux-amd64.yml
+
+  build-linux-arm64:
+    uses: ./.github/workflows/build-linux-arm64.yml
+
+  build-darwin-amd64:
+    uses: ./.github/workflows/build-darwin-amd64.yml
+
+  build-darwin-arm64:
+    uses: ./.github/workflows/build-darwin-arm64.yml

--- a/.github/workflows/build-darwin-amd64.yml
+++ b/.github/workflows/build-darwin-amd64.yml
@@ -1,0 +1,60 @@
+name: Build Darwin AMD64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-13
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+
+      - name: Set environment variables
+        run: |
+          MINIWASM_NETWORK_NAME="minievm-1"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV        
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+          echo "GOOS=darwin" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
+
+      - name: Ensure dependencies
+        run: |
+          go mod tidy
+
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+          echo "ARCH_NAME=${ARCH_NAME}"
+          echo "WASMVM_VERSION=${WASMVM_VERSION}"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
+
+      - name: Build and Package for Darwin ADM642
+        run: |
+          cd ../minievm \
+          && make build \
+          && cd ./build \
+          && tar -czvf minievm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz ./minitiad \
+          && mv ./minievm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./minitiad   
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            minievm_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -1,0 +1,58 @@
+
+name: Build Darwin ARM64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+      - name: Set environment variables
+        run: |
+          MINIWASM_NETWORK_NAME="minievm-1"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}" >> $GITHUB_ENV 
+          echo "GOARCH=arm64" >> $GITHUB_ENV
+          echo "GOOS=darwin" >> $GITHUB_ENV
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=aarch64" >> $GITHUB_ENV
+          
+      - name: Ensure dependencies
+        run: |
+          go mod tidy
+          
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+          echo "ARCH_NAME=${ARCH_NAME}"
+          echo "MINIWASM_NETWORK_NAME=${MINIWASM_NETWORK_NAME}"
+
+      - name: Build and Package for Darwin ARM64
+        run: |
+          cd ../minievm \
+          && make build \
+          && cd ./build \
+          && tar -czvf minievm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz ./minitiad \
+          && mv ./minievm_"$VERSION"_Darwin_"$ARCH_NAME".tar.gz $GITHUB_WORKSPACE/ \
+          && rm -rf ./minitiad   
+  
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            minievm_${{ env.VERSION }}_Darwin_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-amd64.yml
+++ b/.github/workflows/build-linux-amd64.yml
@@ -1,0 +1,51 @@
+
+name: Build Linux AMD64
+
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.4'
+
+      - name: Set environment variables
+        run: |
+          echo "GOARCH=amd64" >> $GITHUB_ENV
+          echo "GOOS=linux" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=x86_64" >> $GITHUB_ENV
+
+      - name: Print environment variables
+        run: |
+          echo "GOARCH=${GOARCH}"
+          echo "GOOS=${GOOS}"
+          echo "VERSION=${VERSION}"
+
+      - name: Build for Linux AMD64
+        run: |
+          export GOARCH=${GOARCH}
+          export GOOS=${GOOS}
+          make build
+          cd ./build
+          mkdir -p minievm_${VERSION}
+          mv minitiad minievm_${VERSION}/
+          tar -czvf minievm_${VERSION}_Linux_${ARCH_NAME}.tar.gz minievm_${VERSION}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ./build/minievm_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz

--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,75 @@
+
+name: Build Linux ARM64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set environment variables
+        run: |
+          echo "GOARCH=arm64" >> $GITHUB_ENV
+          echo "GOOS=linux" >> $GITHUB_ENV
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v0.0.0-${GITHUB_SHA::8}"
+          fi
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "ARCH_NAME=aarch64" >> $GITHUB_ENV
+          
+      - name: Build for ARM64
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          # Activate BuildKit and create a new builder
+          docker buildx create --use --name arm64-builder --platform linux/arm64
+          docker buildx inspect --bootstrap
+
+          # Building images for ARM64
+          docker buildx build --platform linux/arm64 --load --tag minitia/minitiad-shared:arm64 . -f Dockerfile.arm64
+
+          # Extract build output using ARM64 images
+          mkdir -p ./build
+          docker create --name temp minitia/minitiad-shared:arm64
+          docker cp temp:/usr/local/bin/minitiad ./build/
+          docker rm temp
+
+          # Packaging of results
+          cd ./build
+          mkdir -p minievm_${VERSION}
+          mv minitiad minievm_${VERSION}/
+          tar -czvf minievm_${VERSION}_Linux_${ARCH_NAME}.tar.gz minievm_${VERSION}
+          mv minievm_${VERSION}_Linux_${ARCH_NAME}.tar.gz ../
+
+          # Check build results
+          cd ..
+          ls -l
+          file minievm_${VERSION}_Linux_${ARCH_NAME}.tar.gz
+
+          # remove builder
+          docker buildx rm arm64-builder
+
+      - name: List files
+        run: ls -l
+        
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+              ./minievm_${{ env.VERSION }}_Linux_${{ env.ARCH_NAME }}.tar.gz

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,29 @@
+FROM arm64v8/golang:1.22-bullseye AS go-builder
+
+# Install minimum necessary dependencies, build Cosmos SDK, remove packages
+RUN apt update
+RUN apt install -y curl git build-essential
+# debug: for live editting in the image
+RUN apt install -y vim
+
+WORKDIR /code
+COPY . /code/
+
+RUN LEDGER_ENABLED=false make build
+
+FROM arm64v8/ubuntu:20.04
+
+WORKDIR /root
+
+COPY --from=go-builder /code/build/minitiad /usr/local/bin/minitiad
+
+# rest server
+EXPOSE 1317
+# grpc
+EXPOSE 9090
+# tendermint p2p
+EXPOSE 26656
+# tendermint rpc
+EXPOSE 26657
+
+CMD ["/usr/local/bin/minitiad", "version"]


### PR DESCRIPTION
## Changes

- Add build-and-upload.yml: Main workflow coordinating build processes
    - Set up matrix strategy for multiple platforms (Linux, Darwin)
    - Trigger builds for amd64 and arm64 architectures
- Add build-darwin-amd64.yml and build-darwin-arm64.yml: Darwin-specific build workflows
    - Configure macOS environment and build process
    - Support amd64 and arm64 architectures separately
- Add build-linux-amd64.yml and build-linux-arm64.yml: Linux-specific build workflows
    - Set up Ubuntu environment and build process
    - Include steps for amd64 and arm64 builds separately
- Implement automatic uploads to GitHub Releases for all builds

## Rationale and Improvement

This PR sets up comprehensive CI/CD pipelines for building minimove binaries across multiple platforms and architectures, ensuring consistent and automated releases. These workflows significantly improve the developer experience by automating the build and release process, reducing manual errors, and ensuring that binaries are available for all supported platforms and architectures.

## Additional Notes

- This PR improves the overall release process and should make it easier for users to access the latest minimove binaries for their specific platform.
- The automated nature of these workflows will help maintain consistency across releases and reduce the workload on maintainers.

## Reviewer Considerations

- Please review the workflow files for any potential security concerns or optimizations.