### PR TITLE
chore: Corrected typo in variable name (txRecept -> txReceipt)

### DIFF
--- a/indexer/reader.go
+++ b/indexer/reader.go
@@ -56,12 +56,12 @@ func (e *EVMIndexerImpl) IterateBlockTxs(ctx context.Context, blockHeight uint64
 func (e *EVMIndexerImpl) IterateBlockTxReceipts(ctx context.Context, blockHeight uint64, cb func(tx *coretypes.Receipt) (bool, error)) error {
 	return e.BlockAndIndexToTxHashMap.Walk(ctx, collections.NewPrefixedPairRange[uint64, uint64](blockHeight), func(key collections.Pair[uint64, uint64], txHashBz []byte) (bool, error) {
 		txHash := common.BytesToHash(txHashBz)
-		txRecept, err := e.TxReceiptByHash(ctx, txHash)
+		txReceipt, err := e.TxReceiptByHash(ctx, txHash)
 		if err != nil {
 			return true, err
 		}
 
-		return cb(txRecept)
+		return cb(txReceipt)
 	})
 }
 


### PR DESCRIPTION
# Description

This PR addresses a small but important correction in the code where the variable txRecept was incorrectly used. It has been updated to the correct term txReceipt to ensure consistency across the project and avoid confusion.

The primary file affected is the code responsible for iterating over transactions and receipts in the EVM indexer, specifically in the IterateBlockTxReceipts function.
## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
- [X] confirmed `!` in the type prefix if API or client breaking change
- [X] targeted the correct branch
- [X] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] included the necessary unit and integration tests
- [X] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [X] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] confirmed all author checklist items have been addressed
- [X] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
