### PR TITLE
refactor: optimization of version extraction from go.mod

### DIFF
--- a/scripts/protoc-swagger-gen.sh
+++ b/scripts/protoc-swagger-gen.sh
@@ -12,12 +12,12 @@ INDEXER_URL=github.com/initia-labs/kvindexer
 CONNECT_URL=github.com/skip-mev/connect
 CONNECT_V=v2
 
-COSMOS_SDK_VERSION=$(cat ./go.mod | grep "$COSMOS_URL v" | sed -n -e "s/^.* //p")
-IBC_VERSION=$(cat ./go.mod | grep "$IBC_URL/$IBC_V v" | sed -n -e "s/^.* //p")
-INITIA_VERSION=$(cat ./go.mod | grep "$INITIA_URL v" | sed -n -e "s/^.* //p")
-OPINIT_VERSION=$(cat ./go.mod | grep "$OPINIT_URL v" | sed -n -e "s/^.* //p")
-INDEXER_VERSION=$(cat ./go.mod | grep "$INDEXER_URL v" | sed -n -e "s/^.* //p")
-CONNECT_VERSION=$(cat ./go.mod | grep "$CONNECT_URL/$CONNECT_V v" | sed -n -e "s/^.* //p")
+COSMOS_SDK_VERSION=$(grep -o "$COSMOS_URL v[^\ ]*" ./go.mod)
+IBC_VERSION=$(grep -o "$IBC_URL/$IBC_V v[^\ ]*" ./go.mod)
+INITIA_VERSION=$(grep -o "$INITIA_URL v[^\ ]*" ./go.mod)
+OPINIT_VERSION=$(grep -o "$OPINIT_URL v[^\ ]*" ./go.mod)
+INDEXER_VERSION=$(grep -o "$INDEXER_URL v[^\ ]*" ./go.mod)
+CONNECT_VERSION=$(grep -o "$CONNECT_URL/$CONNECT_V v[^\ ]*" ./go.mod)
 
 mkdir -p ./third_party
 cd third_party


### PR DESCRIPTION
# Description

I’ve improved the version extraction process from the `go.mod` file. Previously, `cat` was used to read the file, which worked fine, but I’ve replaced it with a more efficient approach using `grep -o`.

This change makes the code more concise and faster, as it eliminates the need to call `cat`.

---

## Author Checklist

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] confirmed all CI checks have passed

## Reviewers Checklist

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed all author checklist items have been addressed
- [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the process for retrieving version details, resulting in a simpler and more maintainable approach without any impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->