### PR TITLE
fix(audit): burn coins error

### DIFF
--- a/x/evm/keeper/erc20_test.go
+++ b/x/evm/keeper/erc20_test.go
@@ -230,6 +230,52 @@ func Test_BurnFromModuleAccount(t *testing.T) {
 	burnERC20(t, ctx, input, evmAddr, evmAddr2, sdk.NewCoin(fooDenom, math.NewInt(50)), false)
 }
 
+func Test_BurnToCommunityPool(t *testing.T) {
+	ctx, input := createDefaultTestInput(t)
+	_, _, addr := keyPubAddr()
+	evmAddr := common.BytesToAddress(addr.Bytes())
+
+	erc20Keeper, err := keeper.NewERC20Keeper(&input.EVMKeeper)
+	require.NoError(t, err)
+
+	contractAddr0 := deployERC20(t, ctx, input, evmAddr, "foo")
+	denom0, _ := types.ContractAddrToDenom(ctx, &input.EVMKeeper, contractAddr0)
+
+	contractAddr1 := deployERC20(t, ctx, input, evmAddr, "bar")
+	denom1, _ := types.ContractAddrToDenom(ctx, &input.EVMKeeper, contractAddr1)
+
+	err = erc20Keeper.MintCoins(ctx, addr, sdk.NewCoins(
+		sdk.NewCoin(denom0, math.NewInt(100)),
+		sdk.NewCoin(denom1, math.NewInt(100)),
+	))
+	require.Error(t, err)
+
+	mintERC20(t, ctx, input, evmAddr, evmAddr, sdk.NewCoin(denom0, math.NewInt(100)), false)
+	mintERC20(t, ctx, input, evmAddr, evmAddr, sdk.NewCoin(denom1, math.NewInt(100)), false)
+
+	amount, err := erc20Keeper.GetBalance(ctx, addr, denom0)
+	require.NoError(t, err)
+	require.Equal(t, math.NewInt(100), amount)
+
+	amount, err = erc20Keeper.GetBalance(ctx, addr, denom1)
+	require.NoError(t, err)
+	require.Equal(t, math.NewInt(100), amount)
+
+	// Community pool should have 0 balance
+	require.Equal(t, math.NewInt(0), input.CommunityPoolKeeper.CommunityPool.AmountOf(denom0))
+	require.Equal(t, math.NewInt(0), input.CommunityPoolKeeper.CommunityPool.AmountOf(denom1))
+
+	// Burn 50 coins of each denom
+	err = erc20Keeper.BurnCoins(ctx, addr, sdk.NewCoins(
+		sdk.NewCoin(denom0, math.NewInt(50)),
+		sdk.NewCoin(denom1, math.NewInt(50)),
+	))
+	require.NoError(t, err)
+
+	require.Equal(t, math.NewInt(50), input.CommunityPoolKeeper.CommunityPool.AmountOf(denom0))
+	require.Equal(t, math.NewInt(50), input.CommunityPoolKeeper.CommunityPool.AmountOf(denom1))
+}
+
 func Test_MintBurn(t *testing.T) {
 	ctx, input := createDefaultTestInput(t)
 	_, _, addr := keyPubAddr()

--- a/x/evm/types/denom.go
+++ b/x/evm/types/denom.go
@@ -17,7 +17,7 @@ type ERC20DenomKeeper interface {
 }
 
 func DenomToContractAddr(ctx context.Context, k ERC20DenomKeeper, denom string) (common.Address, error) {
-	if strings.HasPrefix(denom, DENOM_PREFIX) {
+	if IsERC20Denom(denom) {
 		contractAddrInString := strings.TrimPrefix(denom, DENOM_PREFIX)
 		if !common.IsHexAddress(contractAddrInString) {
 			return common.Address{}, ErrInvalidDenom


### PR DESCRIPTION
If coins are burned multiple times, the community pool amount becomes mismatched.
add test code to cover them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated the process for transferring tokens to the community pool during coin burns into a single operation for improved efficiency.
  - Updated the logic for validating ERC20 token denominations to ensure consistent handling.
- **Bug Fixes**
  - Adjusted coin burn outcomes so that the community pool accurately reflects the correct token amounts.

These improvements enhance transaction consistency and overall efficiency when managing ERC20 tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->