### PR TITLE
Remove unsupported formatters from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ linters:
     - varnamelen
     - tagliatelle
     - wrapcheck
-    - typecheck
   errcheck:
     exclude-functions:
       - fmt:.*
@@ -15,8 +14,6 @@ linters:
 linters-settings:
   gocyclo:
     min-complexity: 11
-  golint:
-    min-confidence: 1.1
 issues:
   exclude:
     - composite


### PR DESCRIPTION
# Description
Removed typecheck from disable and remove settings for golint as they are no longer supported.
 Locally tested per the [official migration guide](https://golangci-lint.run/product/migration-guide/).

## Reviewers Checklist
- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined internal quality assurance processes to enhance overall system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->