### PR TITLE
feat: make filter-max-addresses as configurable

### DIFF
--- a/jsonrpc/backend/backend.go
+++ b/jsonrpc/backend/backend.go
@@ -79,6 +79,9 @@ func NewJSONRPCBackend(
 	if cfg.FilterMaxBlockRange == 0 {
 		cfg.FilterMaxBlockRange = config.DefaultFilterMaxBlockRange
 	}
+	if cfg.FilterMaxAddresses == 0 {
+		cfg.FilterMaxAddresses = config.DefaultFilterMaxAddresses
+	}
 
 	gasMultiplier, err := math.LegacyNewDecFromStr(cfg.GasMultiplier)
 	if err != nil {
@@ -189,4 +192,8 @@ func (b *JSONRPCBackend) FilterTimeout() time.Duration {
 
 func (b *JSONRPCBackend) FilterMaxBlockRange() int {
 	return b.cfg.FilterMaxBlockRange
+}
+
+func (b *JSONRPCBackend) FilterMaxAddresses() int {
+	return b.cfg.FilterMaxAddresses
 }

--- a/jsonrpc/config/config.go
+++ b/jsonrpc/config/config.go
@@ -41,7 +41,7 @@ const (
 	// DefaultFilterMaxBlockRange is the default maximum number of blocks that can be queried in a filter.
 	DefaultFilterMaxBlockRange = 1_000_000
 	// DefaultFilterMaxAddresses is the default maximum number of addresses that can be used in a log filter.
-	DefaultFilterMaxAddresses = 32
+	DefaultFilterMaxAddresses = 100
 	// DefaultLogCacheSize is the maximum number of cached blocks.
 	DefaultLogCacheSize = 32
 	// DefaultGasMultiplier is the default gas multiplier for the EVM state transition.

--- a/jsonrpc/config/config.go
+++ b/jsonrpc/config/config.go
@@ -40,6 +40,8 @@ const (
 	DefaultFilterTimeout = 5 * time.Minute
 	// DefaultFilterMaxBlockRange is the default maximum number of blocks that can be queried in a filter.
 	DefaultFilterMaxBlockRange = 1_000_000
+	// DefaultFilterMaxAddresses is the default maximum number of addresses that can be used in a log filter.
+	DefaultFilterMaxAddresses = 32
 	// DefaultLogCacheSize is the maximum number of cached blocks.
 	DefaultLogCacheSize = 32
 	// DefaultGasMultiplier is the default gas multiplier for the EVM state transition.
@@ -69,6 +71,7 @@ const (
 	flagJSONRPCLogCacheSize         = "json-rpc.log-cache-size"
 	flagJSONRPCGasMultiplier        = "json-rpc.gas-multiplier"
 	flagJSONRPCFilterMaxBlockRange  = "json-rpc.filter-max-block-range"
+	flagJSONRPCFilterMaxAddresses   = "json-rpc.filter-max-addresses"
 )
 
 // JSONRPCConfig defines configuration for the EVM RPC server.
@@ -108,6 +111,8 @@ type JSONRPCConfig struct {
 	LogCacheSize int `mapstructure:"log-cache-size"`
 	// GasMultiplier is the gas multiplier for the EVM state transition.
 	GasMultiplier string `mapstructure:"gas-multiplier"`
+	// FilterMaxAddresses is the maximum number of addresses that can be used in a log filter.
+	FilterMaxAddresses int `mapstructure:"filter-max-addresses"`
 }
 
 // DefaultJSONRPCConfig returns a default configuration for the EVM RPC server.
@@ -133,8 +138,8 @@ func DefaultJSONRPCConfig() JSONRPCConfig {
 
 		FilterTimeout:       DefaultFilterTimeout,
 		FilterMaxBlockRange: DefaultFilterMaxBlockRange,
-
-		LogCacheSize: DefaultLogCacheSize,
+		FilterMaxAddresses:  DefaultFilterMaxAddresses,
+		LogCacheSize:        DefaultLogCacheSize,
 
 		GasMultiplier: DefaultGasMultiplier,
 	}
@@ -157,6 +162,7 @@ func AddConfigFlags(startCmd *cobra.Command) {
 	startCmd.Flags().Int(flagJSONRPCFeeHistoryMaxBlocks, DefaultFeeHistoryMaxBlocks, "Maximum number of blocks used to lookup the fee history")
 	startCmd.Flags().Duration(flagJSONRPCFilterTimeout, DefaultFilterTimeout, "Duration how long filters stay active")
 	startCmd.Flags().Int(flagJSONRPCFilterMaxBlockRange, DefaultFilterMaxBlockRange, "Maximum number of blocks that can be queried in a filter")
+	startCmd.Flags().Int(flagJSONRPCFilterMaxAddresses, DefaultFilterMaxAddresses, "Maximum number of addresses that can be used in a log filter")
 	startCmd.Flags().Int(flagJSONRPCLogCacheSize, DefaultLogCacheSize, "Maximum number of cached blocks for the log filter")
 	startCmd.Flags().String(flagJSONRPCGasMultiplier, DefaultGasMultiplier, "Gas multiplier for the EVM state transition")
 }
@@ -179,6 +185,7 @@ func GetConfig(appOpts servertypes.AppOptions) JSONRPCConfig {
 		FeeHistoryMaxBlocks:  cast.ToInt(appOpts.Get(flagJSONRPCFeeHistoryMaxBlocks)),
 		FilterTimeout:        cast.ToDuration(appOpts.Get(flagJSONRPCFilterTimeout)),
 		FilterMaxBlockRange:  cast.ToInt(appOpts.Get(flagJSONRPCFilterMaxBlockRange)),
+		FilterMaxAddresses:   cast.ToInt(appOpts.Get(flagJSONRPCFilterMaxAddresses)),
 		LogCacheSize:         cast.ToInt(appOpts.Get(flagJSONRPCLogCacheSize)),
 		GasMultiplier:        cast.ToString(appOpts.Get(flagJSONRPCGasMultiplier)),
 	}
@@ -238,6 +245,9 @@ filter-timeout = "{{ .JSONRPCConfig.FilterTimeout }}"
 
 # FilterMaxBlockRange is the maximum number of blocks that can be queried in a filter.
 filter-max-block-range = {{ .JSONRPCConfig.FilterMaxBlockRange }}
+
+# FilterMaxAddresses is the maximum number of addresses that can be used in a log filter.
+filter-max-addresses = {{ .JSONRPCConfig.FilterMaxAddresses }}
 
 # LogCacheSize is the maximum number of cached blocks for the log filter.
 log-cache-size = {{ .JSONRPCConfig.LogCacheSize }}

--- a/jsonrpc/namespaces/eth/filters/api.go
+++ b/jsonrpc/namespaces/eth/filters/api.go
@@ -29,9 +29,6 @@ var (
 // The maximum number of topic criteria allowed, vm.LOG4 - vm.LOG0
 const maxTopics = 4
 
-// The maximum number of addresses allowed in a filter
-const maxAddresses = 32
-
 type filter struct {
 	hashes []common.Hash
 	txs    []*rpctypes.RPCTransaction
@@ -292,7 +289,7 @@ func (api *FilterAPI) NewBlockFilter() (rpc.ID, error) {
 func (api *FilterAPI) NewFilter(crit ethfilters.FilterCriteria) (rpc.ID, error) {
 	if len(crit.Topics) > maxTopics {
 		return "", errExceedMaxTopics
-	} else if len(crit.Addresses) > maxAddresses {
+	} else if len(crit.Addresses) > api.backend.FilterMaxAddresses() {
 		return "", errExceedMaxAddrs
 	}
 
@@ -365,7 +362,7 @@ func (api *FilterAPI) NewFilter(crit ethfilters.FilterCriteria) (rpc.ID, error) 
 func (api *FilterAPI) GetLogs(ctx context.Context, crit ethfilters.FilterCriteria) ([]*coretypes.Log, error) {
 	if len(crit.Topics) > maxTopics {
 		return nil, errExceedMaxTopics
-	} else if len(crit.Addresses) > maxAddresses {
+	} else if len(crit.Addresses) > api.backend.FilterMaxAddresses() {
 		return nil, errExceedMaxAddrs
 	}
 	var filter *Filter

--- a/jsonrpc/namespaces/eth/filters/subscriptions.go
+++ b/jsonrpc/namespaces/eth/filters/subscriptions.go
@@ -81,7 +81,7 @@ func (api *FilterAPI) Logs(ctx context.Context, crit ethfilters.FilterCriteria) 
 
 	if len(crit.Topics) > maxTopics {
 		return &rpc.Subscription{}, errExceedMaxTopics
-	} else if len(crit.Addresses) > maxAddresses {
+	} else if len(crit.Addresses) > api.backend.FilterMaxAddresses() {
 		return &rpc.Subscription{}, errExceedMaxAddrs
 	}
 


### PR DESCRIPTION
# Description

This PR introduces a new configuration option to allow setting the maximum number of addresses supported by a filter. Previously, this value was hardcoded, which limited flexibility. Making it configurable improves adaptability for different use cases and environments.

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
<!-- * `feat`: A new feature
* `fix`: A bug fix
* `docs`: Documentation only changes
* `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
* `refactor`: A code change that neither fixes a bug nor adds a feature
* `perf`: A code change that improves performance
* `test`: Adding missing tests or correcting existing tests
* `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
* `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
* `chore`: Other changes that don't modify src or test files
* `revert`: Reverts a previous commit -->
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable limit for the maximum number of addresses allowed in log filters, with a default value of 100.
  - Introduced a new command-line flag and configuration option to set the maximum allowed addresses in filters.

- **Improvements**
  - Address limit validation in filters now uses the configurable value instead of a fixed constant, allowing greater flexibility for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->