### PR TITLE
refactor(indexer): remove context from storage accessors

### DIFF
--- a/indexer/abci.go
+++ b/indexer/abci.go
@@ -85,7 +85,7 @@ func (e *EVMIndexerImpl) indexingLoop() {
 		if err != nil {
 			e.logger.Error("indexingLoop error", "err", err)
 		} else if needBackfill {
-			lastIndexedHeight, err := e.GetLastIndexedHeight(context.Background())
+			lastIndexedHeight, err := e.GetLastIndexedHeight()
 			if err != nil {
 				e.logger.Error("failed to get last indexed height", "err", err)
 				continue
@@ -117,9 +117,6 @@ func (e *EVMIndexerImpl) doIndexing(args *indexingArgs, req *abci.RequestFinaliz
 		}
 	}()
 
-	// TODO: Consider removing context usage across all getter and setter methods since they are only used for consistency.
-	// Currently keeping it to maintain uniform API patterns across the collections.Map interface and other storage operations.
-	ctx := context.Background()
 	ethTxInfos, err_ := extractEthTxInfos(e.logger, args, req, res)
 	if err_ != nil {
 		err = fmt.Errorf("failed to extract eth tx infos: %w", err_)
@@ -139,11 +136,11 @@ func (e *EVMIndexerImpl) doIndexing(args *indexingArgs, req *abci.RequestFinaliz
 		contractAddr := ethTxInfo.ContractAddr
 
 		// index tx hash
-		if err_ := e.TxHashToCosmosTxHash.Set(ctx, ethTx.Hash().Bytes(), cosmosTxHash); err_ != nil {
+		if err_ := e.TxHashToCosmosTxHash.Set(storageCtx, ethTx.Hash().Bytes(), cosmosTxHash); err_ != nil {
 			err = fmt.Errorf("failed to store tx hash to cosmos tx hash: %w", err_)
 			return
 		}
-		if err_ := e.CosmosTxHashToTxHash.Set(ctx, cosmosTxHash, ethTx.Hash().Bytes()); err_ != nil {
+		if err_ := e.CosmosTxHashToTxHash.Set(storageCtx, cosmosTxHash, ethTx.Hash().Bytes()); err_ != nil {
 			err = fmt.Errorf("failed to store cosmos tx hash to tx hash: %w", err_)
 			return
 		}
@@ -184,7 +181,7 @@ func (e *EVMIndexerImpl) doIndexing(args *indexingArgs, req *abci.RequestFinaliz
 	parentHash := common.Hash{}
 	if blockHeight > 1 {
 		parentNumber := uint64(blockHeight - 1)
-		parentHeader, err_ := e.BlockHeaderByNumber(ctx, parentNumber)
+		parentHeader, err_ := e.BlockHeaderByNumber(parentNumber)
 		if err_ != nil && errors.Is(err_, collections.ErrNotFound) {
 			return true, nil
 		} else if err_ != nil {
@@ -228,24 +225,24 @@ func (e *EVMIndexerImpl) doIndexing(args *indexingArgs, req *abci.RequestFinaliz
 		blockLogIndex += uint(len(receipt.Logs))
 
 		// store the block-scoped starting log index for this tx
-		if err_ := e.TxStartLogIndexMap.Set(ctx, txHash.Bytes(), uint64(txStartLogIndex)); err_ != nil {
+		if err_ := e.TxStartLogIndexMap.Set(storageCtx, txHash.Bytes(), uint64(txStartLogIndex)); err_ != nil {
 			err = fmt.Errorf("failed to store tx start log index: %w", err_)
 			return
 		}
 
 		// store tx
 		rpcTx := rpctypes.NewRPCTransaction(ethTx, blockHash, uint64(blockHeight), uint64(receipt.TransactionIndex), ethTx.ChainId())
-		if err_ := e.TxMap.Set(ctx, txHash.Bytes(), *rpcTx); err_ != nil {
+		if err_ := e.TxMap.Set(storageCtx, txHash.Bytes(), *rpcTx); err_ != nil {
 			err = fmt.Errorf("failed to store rpcTx: %w", err_)
 			return
 		}
-		if err_ := e.TxReceiptMap.Set(ctx, txHash.Bytes(), *receipt); err_ != nil {
+		if err_ := e.TxReceiptMap.Set(storageCtx, txHash.Bytes(), *receipt); err_ != nil {
 			err = fmt.Errorf("failed to store tx receipt: %w", err_)
 			return
 		}
 
 		// store index
-		if err_ := e.BlockAndIndexToTxHashMap.Set(ctx, collections.Join(uint64(blockHeight), uint64(receipt.TransactionIndex)), txHash.Bytes()); err_ != nil {
+		if err_ := e.BlockAndIndexToTxHashMap.Set(storageCtx, collections.Join(uint64(blockHeight), uint64(receipt.TransactionIndex)), txHash.Bytes()); err_ != nil {
 			err = fmt.Errorf("failed to store blockAndIndexToTxHash: %w", err_)
 			return
 		}
@@ -268,11 +265,11 @@ func (e *EVMIndexerImpl) doIndexing(args *indexingArgs, req *abci.RequestFinaliz
 	}
 
 	// index block header
-	if err_ := e.BlockHeaderMap.Set(ctx, uint64(blockHeight), blockHeader); err_ != nil {
+	if err_ := e.BlockHeaderMap.Set(storageCtx, uint64(blockHeight), blockHeader); err_ != nil {
 		err = fmt.Errorf("failed to marshal blockHeader: %w", err_)
 		return
 	}
-	if err_ := e.BlockHashToNumberMap.Set(ctx, blockHash.Bytes(), uint64(blockHeight)); err_ != nil {
+	if err_ := e.BlockHashToNumberMap.Set(storageCtx, blockHash.Bytes(), uint64(blockHeight)); err_ != nil {
 		err = fmt.Errorf("failed to store blockHashToNumber: %w", err_)
 		return
 	}
@@ -300,11 +297,11 @@ func (e *EVMIndexerImpl) doIndexing(args *indexingArgs, req *abci.RequestFinaliz
 
 	// execute pruning only if retain height is set
 	if e.retainHeight > 0 {
-		e.doPrune(ctx, uint64(blockHeight))
+		e.doPrune(storageCtx, uint64(blockHeight))
 	}
 
 	// trigger bloom indexing
-	e.doBloomIndexing(ctx, uint64(blockHeight))
+	e.doBloomIndexing(storageCtx, uint64(blockHeight))
 
 	e.logger.Info("evm indexer indexed", "blockHeight", blockHeight)
 

--- a/indexer/abci_test.go
+++ b/indexer/abci_test.go
@@ -49,7 +49,7 @@ func Test_ListenFinalizeBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// check the tx is indexed
-	evmTx, err := indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
@@ -60,25 +60,25 @@ func Test_ListenFinalizeBlock(t *testing.T) {
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], true)
 
 	// listen finalize block
-	ctx, closer, err = app.CreateQueryContext(0, false)
+	_, closer, err = app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
 	// check the tx is indexed
-	evmTx, err = indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
 	// check the block header is indexed
-	header, err := indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height))
+	header, err := indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))
 	require.NoError(t, err)
 	require.NotNil(t, header)
 	require.Equal(t, finalizeReq.Height, header.Number.Int64())
 
 	// check the tx is indexed
-	ih, err := indexer.GetLastIndexedHeight(ctx)
+	ih, err := indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))
 
@@ -102,22 +102,22 @@ func Test_ListenFinalizeBlock(t *testing.T) {
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], true)
 
 	// check the block header is indexed
-	header, err = indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height))
+	header, err = indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))
 	require.NoError(t, err)
 	require.NotNil(t, header)
 	require.Equal(t, finalizeReq.Height, header.Number.Int64())
 
 	// check the tx is indexed
-	evmTxHash, err = indexer.TxHashByCosmosTxHash(ctx, cosmosTxHash)
+	evmTxHash, err = indexer.TxHashByCosmosTxHash(cosmosTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTxHash)
 
-	evmTx, err = indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
 	// check the tx is indexed
-	ih, err = indexer.GetLastIndexedHeight(ctx)
+	ih, err = indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))
 
@@ -135,18 +135,18 @@ func Test_ListenFinalizeBlock(t *testing.T) {
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], true)
 
 	// check the block header is indexed
-	header, err = indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height))
+	header, err = indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))
 	require.NoError(t, err)
 	require.NotNil(t, header)
 	require.Equal(t, finalizeReq.Height, header.Number.Int64())
 
 	// check the tx is indexed
-	ih, err = indexer.GetLastIndexedHeight(ctx)
+	ih, err = indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))
 
 	// check the tx is not indexed
-	_, err = indexer.TxHashByCosmosTxHash(ctx, cosmosTxHash)
+	_, err = indexer.TxHashByCosmosTxHash(cosmosTxHash)
 	require.ErrorIs(t, err, collections.ErrNotFound)
 
 	// 4. Test that failed Cosmos transactions are not indexed
@@ -166,17 +166,17 @@ func Test_ListenFinalizeBlock(t *testing.T) {
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], false)
 
 	// check the block header is indexed
-	header, err = indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height))
+	header, err = indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))
 	require.NoError(t, err)
 	require.NotNil(t, header)
 
 	// check the tx is indexed
-	ih, err = indexer.GetLastIndexedHeight(ctx)
+	ih, err = indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))
 
 	// check the tx is not indexed
-	_, err = indexer.TxHashByCosmosTxHash(ctx, cosmosTxHash)
+	_, err = indexer.TxHashByCosmosTxHash(cosmosTxHash)
 	require.ErrorIs(t, err, collections.ErrNotFound)
 }
 
@@ -252,13 +252,13 @@ func Test_ListenFinalizeBlock_Subscribe_CancelBeforeDrain(t *testing.T) {
 	indexer.Wait()
 
 	// Block should still be indexed in storage despite subscriber cancellation
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
-	ih, err := indexer.GetLastIndexedHeight(ctx)
+	ih, err := indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))
 
@@ -293,13 +293,13 @@ func Test_ListenFinalizeBlock_ContractCreation(t *testing.T) {
 	require.NoError(t, err)
 
 	// check the tx is indexed
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
-	receipt, err := indexer.TxReceiptByHash(ctx, evmTxHash)
+	receipt, err := indexer.TxReceiptByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 

--- a/indexer/abci_test.go
+++ b/indexer/abci_test.go
@@ -244,6 +244,7 @@ func Test_ListenFinalizeBlock_Subscribe_CancelBeforeDrain(t *testing.T) {
 	// Wait for indexing to complete
 	indexer.Wait()
 
+	// Block should still be indexed in storage despite subscriber cancellation
 	ih, err := indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))

--- a/indexer/abci_test.go
+++ b/indexer/abci_test.go
@@ -59,13 +59,6 @@ func Test_ListenFinalizeBlock(t *testing.T) {
 	finalizeReq, finalizeRes := tests.ExecuteTxs(t, app, tx)
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], true)
 
-	// listen finalize block
-	_, closer, err = app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
-
 	// check the tx is indexed
 	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
@@ -251,13 +244,6 @@ func Test_ListenFinalizeBlock_Subscribe_CancelBeforeDrain(t *testing.T) {
 	// Wait for indexing to complete
 	indexer.Wait()
 
-	// Block should still be indexed in storage despite subscriber cancellation
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
-
 	ih, err := indexer.GetLastIndexedHeight()
 	require.NoError(t, err)
 	require.Equal(t, finalizeReq.Height, int64(ih))
@@ -290,13 +276,6 @@ func Test_ListenFinalizeBlock_ContractCreation(t *testing.T) {
 	require.Equal(t, evmtypes.EventTypeContractCreated, createEvent.GetType())
 
 	contractAddr, err := hexutil.Decode(createEvent.Attributes[0].Value)
-	require.NoError(t, err)
-
-	// check the tx is indexed
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
 	require.NoError(t, err)
 
 	receipt, err := indexer.TxReceiptByHash(evmTxHash)

--- a/indexer/abci_test.go
+++ b/indexer/abci_test.go
@@ -279,6 +279,7 @@ func Test_ListenFinalizeBlock_ContractCreation(t *testing.T) {
 	contractAddr, err := hexutil.Decode(createEvent.Attributes[0].Value)
 	require.NoError(t, err)
 
+	// check the tx is indexed
 	receipt, err := indexer.TxReceiptByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)

--- a/indexer/bloom.go
+++ b/indexer/bloom.go
@@ -36,10 +36,11 @@ func (e *EVMIndexerImpl) doBloomIndexing(ctx context.Context, height uint64) {
 func (e *EVMIndexerImpl) bloomLoop() {
 	defer close(e.bloomDoneCh)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	for {
 		select {
 		case <-e.bloomStopCh:
+			cancel()
 			return
 		case <-e.bloomNotifyCh:
 		}

--- a/indexer/bloom.go
+++ b/indexer/bloom.go
@@ -82,7 +82,7 @@ func (e *EVMIndexerImpl) bloomLoop() {
 
 // bloomIndexing generates the bloom index if the current section is complete.
 func (e *EVMIndexerImpl) bloomIndexing(ctx context.Context, height uint64) error {
-	section, err := e.PeekBloomBitsNextSection(ctx)
+	section, err := e.PeekBloomBitsNextSection()
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (e *EVMIndexerImpl) bloomIndexing(ctx context.Context, height uint64) error
 		}
 
 		height := section*evmconfig.SectionSize + i
-		header, err := e.BlockHeaderByNumber(ctx, height)
+		header, err := e.BlockHeaderByNumber(height)
 		if err != nil && errors.Is(err, collections.ErrNotFound) {
 			// pruned block, create a dummy header
 			header = &coretypes.Header{
@@ -128,13 +128,13 @@ func (e *EVMIndexerImpl) bloomIndexing(ctx context.Context, height uint64) error
 			return err
 		}
 
-		if err := e.RecordBloomBits(ctx, section, uint32(i), bits); err != nil {
+		if err := e.RecordBloomBits(section, uint32(i), bits); err != nil {
 			return err
 		}
 	}
 
 	// increment the section number; if this fails, the section will be reprocessed
-	if err := e.NextBloomBitsSection(ctx); err != nil {
+	if err := e.NextBloomBitsSection(); err != nil {
 		return err
 	}
 
@@ -145,8 +145,8 @@ func (e *EVMIndexerImpl) bloomIndexing(ctx context.Context, height uint64) error
 }
 
 // ReadBloomBits reads the bloom bits for the given index, section and hash.
-func (e *EVMIndexerImpl) ReadBloomBits(ctx context.Context, section uint64, index uint32) ([]byte, error) {
-	bloomBits, err := e.BloomBits.Get(ctx, collections.Join(section, index))
+func (e *EVMIndexerImpl) ReadBloomBits(section uint64, index uint32) ([]byte, error) {
+	bloomBits, err := e.BloomBits.Get(storageCtx, collections.Join(section, index))
 	if err != nil {
 		return nil, err
 	}
@@ -155,19 +155,19 @@ func (e *EVMIndexerImpl) ReadBloomBits(ctx context.Context, section uint64, inde
 }
 
 // RecordBloomBits records the bloom bits for the given index, section and hash.
-func (e *EVMIndexerImpl) RecordBloomBits(ctx context.Context, section uint64, index uint32, bloomBits []byte) error {
-	return e.BloomBits.Set(ctx, collections.Join(section, index), bloomBits)
+func (e *EVMIndexerImpl) RecordBloomBits(section uint64, index uint32, bloomBits []byte) error {
+	return e.BloomBits.Set(storageCtx, collections.Join(section, index), bloomBits)
 }
 
 // NextBloomBitsSection increments the section number.
-func (e *EVMIndexerImpl) NextBloomBitsSection(ctx context.Context) error {
-	_, err := e.BloomBitsNextSection.Next(ctx)
+func (e *EVMIndexerImpl) NextBloomBitsSection() error {
+	_, err := e.BloomBitsNextSection.Next(storageCtx)
 	return err
 }
 
 // PeekBloomBitsNextSection returns the next section number to be processed.
-func (e *EVMIndexerImpl) PeekBloomBitsNextSection(ctx context.Context) (uint64, error) {
-	return e.BloomBitsNextSection.Peek(ctx)
+func (e *EVMIndexerImpl) PeekBloomBitsNextSection() (uint64, error) {
+	return e.BloomBitsNextSection.Peek(storageCtx)
 }
 
 // Check if bloom indexing is running

--- a/indexer/bloom_test.go
+++ b/indexer/bloom_test.go
@@ -49,19 +49,19 @@ func Test_BloomIndexing(t *testing.T) {
 		return indexer.GetLastBloomIndexedHeight() >= evmconfig.SectionSize
 	}, 10*time.Second, 50*time.Millisecond)
 
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
 	for i := range uint32(coretypes.BloomBitLength) {
-		bloomBits, err := indexer.ReadBloomBits(ctx, 0, i)
+		bloomBits, err := indexer.ReadBloomBits(0, i)
 		require.NoError(t, err)
 		require.NotNil(t, bloomBits)
 	}
 
-	nextSection, err := indexer.PeekBloomBitsNextSection(ctx)
+	nextSection, err := indexer.PeekBloomBitsNextSection()
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), nextSection)
 }

--- a/indexer/bloom_test.go
+++ b/indexer/bloom_test.go
@@ -49,12 +49,6 @@ func Test_BloomIndexing(t *testing.T) {
 		return indexer.GetLastBloomIndexedHeight() >= evmconfig.SectionSize
 	}, 10*time.Second, 50*time.Millisecond)
 
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
-
 	for i := range uint32(coretypes.BloomBitLength) {
 		bloomBits, err := indexer.ReadBloomBits(0, i)
 		require.NoError(t, err)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -38,23 +38,23 @@ type EVMIndexer interface {
 	storetypes.ABCIListener
 
 	// tx
-	TxByHash(ctx context.Context, hash common.Hash) (*rpctypes.RPCTransaction, error)
-	IterateBlockTxs(ctx context.Context, blockHeight uint64, cb func(tx *rpctypes.RPCTransaction) (bool, error)) error
-	TxHashByBlockAndIndex(ctx context.Context, blockHeight uint64, index uint64) (common.Hash, error)
+	TxByHash(hash common.Hash) (*rpctypes.RPCTransaction, error)
+	IterateBlockTxs(blockHeight uint64, cb func(tx *rpctypes.RPCTransaction) (bool, error)) error
+	TxHashByBlockAndIndex(blockHeight uint64, index uint64) (common.Hash, error)
 
 	// tx receipt
-	TxReceiptByHash(ctx context.Context, hash common.Hash) (*coretypes.Receipt, error)
-	IterateBlockTxReceipts(ctx context.Context, blockHeight uint64, cb func(tx *coretypes.Receipt) (bool, error)) error
-	TxStartLogIndexByHash(ctx context.Context, hash common.Hash) (uint64, error)
-	StoreTxStartLogIndex(ctx context.Context, hash common.Hash, index uint64) error
+	TxReceiptByHash(hash common.Hash) (*coretypes.Receipt, error)
+	IterateBlockTxReceipts(blockHeight uint64, cb func(tx *coretypes.Receipt) (bool, error)) error
+	TxStartLogIndexByHash(hash common.Hash) (uint64, error)
+	StoreTxStartLogIndex(hash common.Hash, index uint64) error
 
 	// block
-	BlockHashToNumber(ctx context.Context, hash common.Hash) (uint64, error)
-	BlockHeaderByNumber(ctx context.Context, number uint64) (*coretypes.Header, error)
+	BlockHashToNumber(hash common.Hash) (uint64, error)
+	BlockHeaderByNumber(number uint64) (*coretypes.Header, error)
 
 	// cosmos tx hash
-	CosmosTxHashByTxHash(ctx context.Context, hash common.Hash) ([]byte, error)
-	TxHashByCosmosTxHash(ctx context.Context, hash []byte) (common.Hash, error)
+	CosmosTxHashByTxHash(hash common.Hash) ([]byte, error)
+	TxHashByCosmosTxHash(hash []byte) (common.Hash, error)
 
 	// event subscription
 	Subscribe() (chan *coretypes.Header, chan []*coretypes.Log, func())
@@ -63,11 +63,11 @@ type EVMIndexer interface {
 	MempoolCache() *MempoolTxCache
 
 	// last indexed height
-	GetLastIndexedHeight(ctx context.Context) (uint64, error)
+	GetLastIndexedHeight() (uint64, error)
 
 	// bloom
-	ReadBloomBits(ctx context.Context, section uint64, index uint32) ([]byte, error)
-	PeekBloomBitsNextSection(ctx context.Context) (uint64, error)
+	ReadBloomBits(section uint64, index uint32) ([]byte, error)
+	PeekBloomBitsNextSection() (uint64, error)
 	IsBloomIndexingRunning() bool
 
 	// Close stops the indexer process, waits for pending operations to complete,
@@ -81,6 +81,8 @@ type EVMIndexer interface {
 	// Initialize sets the client context.
 	Initialize(clientCtx client.Context, contextCreator contextCreator, consensusParamsGetter consensusParamsGetter) error
 }
+
+var storageCtx = context.Background()
 
 // contextCreator creates a new SDK context.
 type contextCreator func(height int64, prove bool) (sdk.Context, io.Closer, error)
@@ -251,7 +253,7 @@ func (e *EVMIndexerImpl) Initialize(clientCtx client.Context, contextCreator con
 	e.consensusParamsGetter = consensusParamsGetter
 
 	if e.backfillStartHeight != 0 {
-		lastIndexedHeight, err := e.GetLastIndexedHeight(context.Background())
+		lastIndexedHeight, err := e.GetLastIndexedHeight()
 		if err != nil {
 			e.logger.Error("failed to get last indexed height", "err", err)
 			return err
@@ -314,11 +316,11 @@ func (e *EVMIndexerImpl) Subscribe() (chan *coretypes.Header, chan []*coretypes.
 	return sub.blockChan, sub.logsChan, cancel
 }
 
-func (e *EVMIndexerImpl) GetLastIndexedHeight(ctx context.Context) (uint64, error) {
+func (e *EVMIndexerImpl) GetLastIndexedHeight() (uint64, error) {
 	// if lastIndexedHeight is not set, get the last indexed block header from the store
 	lastIndexedHeight := e.lastIndexedHeight.Load()
 	if lastIndexedHeight == 0 {
-		blockHeader, err := e.BlockHeaderMap.Iterate(ctx, new(collections.Range[uint64]).Descending())
+		blockHeader, err := e.BlockHeaderMap.Iterate(storageCtx, new(collections.Range[uint64]).Descending())
 		if err != nil {
 			return 0, err
 		}
@@ -356,8 +358,8 @@ func (e *EVMIndexerImpl) isPruneIdle() bool {
 // isBloomIdle reports whether bloom indexing has no processable backlog.
 // A requested height inside an incomplete section is not processable yet, so
 // this can still return true in that case.
-func (e *EVMIndexerImpl) isBloomIdle(ctx context.Context) (bool, error) {
-	nextBloomSection, err := e.PeekBloomBitsNextSection(ctx)
+func (e *EVMIndexerImpl) isBloomIdle() (bool, error) {
+	nextBloomSection, err := e.PeekBloomBitsNextSection()
 	if err != nil {
 		return false, err
 	}
@@ -434,7 +436,7 @@ func (e *EVMIndexerImpl) flushStore() error {
 	for {
 		select {
 		case <-ticker.C:
-			bloomIdle, err := e.isBloomIdle(context.Background())
+			bloomIdle, err := e.isBloomIdle()
 			if err != nil {
 				return fmt.Errorf("failed to read next bloom section while flushing store: %w", err)
 			}

--- a/indexer/log_index_test.go
+++ b/indexer/log_index_test.go
@@ -50,24 +50,24 @@ func Test_TxStartLogIndex(t *testing.T) {
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], true)
 	tests.CheckTxResult(t, finalizeRes.TxResults[1], true)
 
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
 	// tx1 is the first tx in the block — its start log index must be 0
-	start1, err := indexer.TxStartLogIndexByHash(ctx, evmHash1)
+	start1, err := indexer.TxStartLogIndexByHash(evmHash1)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), start1, "first tx start log index should be 0")
 
 	// tx2 follows tx1 which emitted 1 log — its start log index must be 1
-	receipt1, err := indexer.TxReceiptByHash(ctx, evmHash1)
+	receipt1, err := indexer.TxReceiptByHash(evmHash1)
 	require.NoError(t, err)
 	logsInTx1 := uint64(len(receipt1.Logs))
 	require.Greater(t, logsInTx1, uint64(0), "tx1 must have emitted at least one log")
 
-	start2, err := indexer.TxStartLogIndexByHash(ctx, evmHash2)
+	start2, err := indexer.TxStartLogIndexByHash(evmHash2)
 	require.NoError(t, err)
 	require.Equal(t, logsInTx1, start2, "second tx start log index should equal number of logs in first tx")
 }
@@ -112,17 +112,17 @@ func Test_TxStartLogIndex_Pruned(t *testing.T) {
 		return indexer.GetLastPruneTriggerHeight() >= uint64(finalizeReq.Height)
 	}, 10*time.Second, 50*time.Millisecond, "timed out waiting for pruning to finish")
 
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
 	// pruned tx's start log index should be gone
-	_, err = indexer.TxStartLogIndexByHash(ctx, evmHashPruned)
+	_, err = indexer.TxStartLogIndexByHash(evmHashPruned)
 	require.ErrorIs(t, err, collections.ErrNotFound, "start log index for pruned tx should be removed")
 
 	// kept tx's start log index should still be present
-	_, err = indexer.TxStartLogIndexByHash(ctx, evmHashKept)
+	_, err = indexer.TxStartLogIndexByHash(evmHashKept)
 	require.NoError(t, err, "start log index for retained tx should still exist")
 }

--- a/indexer/log_index_test.go
+++ b/indexer/log_index_test.go
@@ -50,12 +50,6 @@ func Test_TxStartLogIndex(t *testing.T) {
 	tests.CheckTxResult(t, finalizeRes.TxResults[0], true)
 	tests.CheckTxResult(t, finalizeRes.TxResults[1], true)
 
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
-
 	// tx1 is the first tx in the block — its start log index must be 0
 	start1, err := indexer.TxStartLogIndexByHash(evmHash1)
 	require.NoError(t, err)
@@ -111,12 +105,6 @@ func Test_TxStartLogIndex_Pruned(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return indexer.GetLastPruneTriggerHeight() >= uint64(finalizeReq.Height)
 	}, 10*time.Second, 50*time.Millisecond, "timed out waiting for pruning to finish")
-
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
 
 	// pruned tx's start log index should be gone
 	_, err = indexer.TxStartLogIndexByHash(evmHashPruned)

--- a/indexer/prune_test.go
+++ b/indexer/prune_test.go
@@ -37,7 +37,6 @@ func Test_PruneIndexer(t *testing.T) {
 	require.NoError(t, err)
 
 	// check the tx is indexed
-	// check the tx is indexed
 	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)

--- a/indexer/prune_test.go
+++ b/indexer/prune_test.go
@@ -37,6 +37,7 @@ func Test_PruneIndexer(t *testing.T) {
 	require.NoError(t, err)
 
 	// check the tx is indexed
+	// check the tx is indexed
 	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)

--- a/indexer/prune_test.go
+++ b/indexer/prune_test.go
@@ -36,13 +36,6 @@ func Test_PruneIndexer(t *testing.T) {
 	contractAddr, err := hexutil.Decode(createEvent.Attributes[0].Value)
 	require.NoError(t, err)
 
-	// listen finalize block
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
-
 	// check the tx is indexed
 	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
@@ -60,13 +53,6 @@ func Test_PruneIndexer(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return indexer.GetLastPruneTriggerHeight() >= uint64(finalizeReq.Height)
 	}, 10*time.Second, 50*time.Millisecond)
-
-	// listen finalize block
-	_, closer, err = app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
 
 	// check the block header is indexed
 	header, err := indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))

--- a/indexer/prune_test.go
+++ b/indexer/prune_test.go
@@ -37,14 +37,14 @@ func Test_PruneIndexer(t *testing.T) {
 	require.NoError(t, err)
 
 	// listen finalize block
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
 	// check the tx is indexed
-	evmTx, err := indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
@@ -62,52 +62,52 @@ func Test_PruneIndexer(t *testing.T) {
 	}, 10*time.Second, 50*time.Millisecond)
 
 	// listen finalize block
-	ctx, closer, err = app.CreateQueryContext(0, false)
+	_, closer, err = app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
 	// check the block header is indexed
-	header, err := indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height))
+	header, err := indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))
 	require.NoError(t, err)
 	require.NotNil(t, header)
 	require.Equal(t, finalizeReq.Height, header.Number.Int64())
 
 	// previous block should be pruned
-	header, err = indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height-1))
+	header, err = indexer.BlockHeaderByNumber(uint64(finalizeReq.Height - 1))
 	require.ErrorIs(t, err, collections.ErrNotFound)
 	require.Nil(t, header)
 
 	// check the tx is indexed
-	evmTx, err = indexer.TxByHash(ctx, evmTxHash2)
+	evmTx, err = indexer.TxByHash(evmTxHash2)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
 	// but the first tx should be pruned
-	evmTx, err = indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.ErrorIs(t, err, collections.ErrNotFound)
 	require.Nil(t, evmTx)
 
 	// check the receipt is indexed
-	receipt, err := indexer.TxReceiptByHash(ctx, evmTxHash2)
+	receipt, err := indexer.TxReceiptByHash(evmTxHash2)
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 
 	// check the receipt is pruned
-	_, err = indexer.TxReceiptByHash(ctx, evmTxHash)
+	_, err = indexer.TxReceiptByHash(evmTxHash)
 	require.ErrorIs(t, err, collections.ErrNotFound)
 
 	// check cosmos tx hash is indexed
-	cosmosTxHash, err := indexer.CosmosTxHashByTxHash(ctx, evmTxHash2)
+	cosmosTxHash, err := indexer.CosmosTxHashByTxHash(evmTxHash2)
 	require.NoError(t, err)
 	require.NotNil(t, cosmosTxHash)
-	evmTxHash3, err := indexer.TxHashByCosmosTxHash(ctx, cosmosTxHash)
+	evmTxHash3, err := indexer.TxHashByCosmosTxHash(cosmosTxHash)
 	require.NoError(t, err)
 	require.Equal(t, evmTxHash2, evmTxHash3)
 
 	// check cosmos tx hash is pruned
-	_, err = indexer.CosmosTxHashByTxHash(ctx, evmTxHash)
+	_, err = indexer.CosmosTxHashByTxHash(evmTxHash)
 	require.ErrorIs(t, err, collections.ErrNotFound)
 }
 

--- a/indexer/reader.go
+++ b/indexer/reader.go
@@ -1,8 +1,6 @@
 package indexer
 
 import (
-	"context"
-
 	"cosmossdk.io/collections"
 	"github.com/ethereum/go-ethereum/common"
 	coretypes "github.com/ethereum/go-ethereum/core/types"
@@ -10,8 +8,8 @@ import (
 )
 
 // BlockHeaderByNumber implements EVMIndexer.
-func (e *EVMIndexerImpl) BlockHeaderByNumber(ctx context.Context, blockNumber uint64) (*coretypes.Header, error) {
-	blockHeader, err := e.BlockHeaderMap.Get(ctx, blockNumber)
+func (e *EVMIndexerImpl) BlockHeaderByNumber(blockNumber uint64) (*coretypes.Header, error) {
+	blockHeader, err := e.BlockHeaderMap.Get(storageCtx, blockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -20,8 +18,8 @@ func (e *EVMIndexerImpl) BlockHeaderByNumber(ctx context.Context, blockNumber ui
 }
 
 // TxHashByBlockAndIndex implements EVMIndexer.
-func (e *EVMIndexerImpl) TxHashByBlockAndIndex(ctx context.Context, blockHeight uint64, index uint64) (common.Hash, error) {
-	txHashBz, err := e.BlockAndIndexToTxHashMap.Get(ctx, collections.Join(blockHeight, index))
+func (e *EVMIndexerImpl) TxHashByBlockAndIndex(blockHeight uint64, index uint64) (common.Hash, error) {
+	txHashBz, err := e.BlockAndIndexToTxHashMap.Get(storageCtx, collections.Join(blockHeight, index))
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -30,8 +28,8 @@ func (e *EVMIndexerImpl) TxHashByBlockAndIndex(ctx context.Context, blockHeight 
 }
 
 // TxByHash implements EVMIndexer.
-func (e *EVMIndexerImpl) TxByHash(ctx context.Context, hash common.Hash) (*rpctypes.RPCTransaction, error) {
-	tx, err := e.TxMap.Get(ctx, hash.Bytes())
+func (e *EVMIndexerImpl) TxByHash(hash common.Hash) (*rpctypes.RPCTransaction, error) {
+	tx, err := e.TxMap.Get(storageCtx, hash.Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -40,10 +38,10 @@ func (e *EVMIndexerImpl) TxByHash(ctx context.Context, hash common.Hash) (*rpcty
 }
 
 // IterateBlockTxs implements EVMIndexer.
-func (e *EVMIndexerImpl) IterateBlockTxs(ctx context.Context, blockHeight uint64, cb func(tx *rpctypes.RPCTransaction) (bool, error)) error {
-	return e.BlockAndIndexToTxHashMap.Walk(ctx, collections.NewPrefixedPairRange[uint64, uint64](blockHeight), func(key collections.Pair[uint64, uint64], txHashBz []byte) (bool, error) {
+func (e *EVMIndexerImpl) IterateBlockTxs(blockHeight uint64, cb func(tx *rpctypes.RPCTransaction) (bool, error)) error {
+	return e.BlockAndIndexToTxHashMap.Walk(storageCtx, collections.NewPrefixedPairRange[uint64, uint64](blockHeight), func(key collections.Pair[uint64, uint64], txHashBz []byte) (bool, error) {
 		txHash := common.BytesToHash(txHashBz)
-		tx, err := e.TxByHash(ctx, txHash)
+		tx, err := e.TxByHash(txHash)
 		if err != nil {
 			return true, err
 		}
@@ -53,10 +51,10 @@ func (e *EVMIndexerImpl) IterateBlockTxs(ctx context.Context, blockHeight uint64
 }
 
 // IterateBlockTxReceipts implements EVMIndexer.
-func (e *EVMIndexerImpl) IterateBlockTxReceipts(ctx context.Context, blockHeight uint64, cb func(tx *coretypes.Receipt) (bool, error)) error {
-	return e.BlockAndIndexToTxHashMap.Walk(ctx, collections.NewPrefixedPairRange[uint64, uint64](blockHeight), func(key collections.Pair[uint64, uint64], txHashBz []byte) (bool, error) {
+func (e *EVMIndexerImpl) IterateBlockTxReceipts(blockHeight uint64, cb func(tx *coretypes.Receipt) (bool, error)) error {
+	return e.BlockAndIndexToTxHashMap.Walk(storageCtx, collections.NewPrefixedPairRange[uint64, uint64](blockHeight), func(key collections.Pair[uint64, uint64], txHashBz []byte) (bool, error) {
 		txHash := common.BytesToHash(txHashBz)
-		txReceipt, err := e.TxReceiptByHash(ctx, txHash)
+		txReceipt, err := e.TxReceiptByHash(txHash)
 		if err != nil {
 			return true, err
 		}
@@ -66,36 +64,36 @@ func (e *EVMIndexerImpl) IterateBlockTxReceipts(ctx context.Context, blockHeight
 }
 
 // TxReceiptByHash implements EVMIndexer.
-func (e *EVMIndexerImpl) TxReceiptByHash(ctx context.Context, hash common.Hash) (*coretypes.Receipt, error) {
-	receipt, err := e.TxReceiptMap.Get(ctx, hash.Bytes())
+func (e *EVMIndexerImpl) TxReceiptByHash(hash common.Hash) (*coretypes.Receipt, error) {
+	receipt, err := e.TxReceiptMap.Get(storageCtx, hash.Bytes())
 	return &receipt, err
 }
 
 // TxStartLogIndexByHash implements EVMIndexer.
 // Returns the block-scoped index of the first log for the given tx.
 // Returns collections.ErrNotFound if not stored (e.g. indexed before this field was introduced).
-func (e *EVMIndexerImpl) TxStartLogIndexByHash(ctx context.Context, hash common.Hash) (uint64, error) {
-	return e.TxStartLogIndexMap.Get(ctx, hash.Bytes())
+func (e *EVMIndexerImpl) TxStartLogIndexByHash(hash common.Hash) (uint64, error) {
+	return e.TxStartLogIndexMap.Get(storageCtx, hash.Bytes())
 }
 
 // StoreTxStartLogIndex implements EVMIndexer.
-func (e *EVMIndexerImpl) StoreTxStartLogIndex(ctx context.Context, hash common.Hash, index uint64) error {
-	return e.TxStartLogIndexMap.Set(ctx, hash.Bytes(), index)
+func (e *EVMIndexerImpl) StoreTxStartLogIndex(hash common.Hash, index uint64) error {
+	return e.TxStartLogIndexMap.Set(storageCtx, hash.Bytes(), index)
 }
 
 // BlockHashToNumber implements EVMIndexer.
-func (e *EVMIndexerImpl) BlockHashToNumber(ctx context.Context, hash common.Hash) (uint64, error) {
-	return e.BlockHashToNumberMap.Get(ctx, hash.Bytes())
+func (e *EVMIndexerImpl) BlockHashToNumber(hash common.Hash) (uint64, error) {
+	return e.BlockHashToNumberMap.Get(storageCtx, hash.Bytes())
 }
 
 // CosmosTxHashByTxHash implements EVMIndexer.
-func (e *EVMIndexerImpl) CosmosTxHashByTxHash(ctx context.Context, hash common.Hash) ([]byte, error) {
-	return e.TxHashToCosmosTxHash.Get(ctx, hash.Bytes())
+func (e *EVMIndexerImpl) CosmosTxHashByTxHash(hash common.Hash) ([]byte, error) {
+	return e.TxHashToCosmosTxHash.Get(storageCtx, hash.Bytes())
 }
 
 // TxHashByCosmosTxHash implements EVMIndexer.
-func (e *EVMIndexerImpl) TxHashByCosmosTxHash(ctx context.Context, hash []byte) (common.Hash, error) {
-	bz, err := e.CosmosTxHashToTxHash.Get(ctx, hash)
+func (e *EVMIndexerImpl) TxHashByCosmosTxHash(hash []byte) (common.Hash, error) {
+	bz, err := e.CosmosTxHashToTxHash.Get(storageCtx, hash)
 	if err != nil {
 		return common.Hash{}, err
 	}

--- a/indexer/reader_test.go
+++ b/indexer/reader_test.go
@@ -33,13 +33,6 @@ func Test_Reader(t *testing.T) {
 	contractAddr, err := hexutil.Decode(createEvent.Attributes[0].Value)
 	require.NoError(t, err)
 
-	// check the tx is indexed
-	_, closer, err := app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
-
 	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
@@ -60,13 +53,6 @@ func Test_Reader(t *testing.T) {
 	cosmosTxHash := cmtTx.Hash()
 	cmtTx2 := cmttypes.Tx(txBytes2)
 	cosmosTxHash2 := cmtTx2.Hash()
-
-	// check the tx is indexed
-	_, closer, err = app.CreateQueryContext(0, false)
-	if closer != nil {
-		defer closer.Close()
-	}
-	require.NoError(t, err)
 
 	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)

--- a/indexer/reader_test.go
+++ b/indexer/reader_test.go
@@ -33,6 +33,7 @@ func Test_Reader(t *testing.T) {
 	contractAddr, err := hexutil.Decode(createEvent.Attributes[0].Value)
 	require.NoError(t, err)
 
+	// check the tx is indexed
 	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
@@ -54,6 +55,7 @@ func Test_Reader(t *testing.T) {
 	cmtTx2 := cmttypes.Tx(txBytes2)
 	cosmosTxHash2 := cmtTx2.Hash()
 
+	// check the tx is indexed
 	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)

--- a/indexer/reader_test.go
+++ b/indexer/reader_test.go
@@ -34,13 +34,13 @@ func Test_Reader(t *testing.T) {
 	require.NoError(t, err)
 
 	// check the tx is indexed
-	ctx, closer, err := app.CreateQueryContext(0, false)
+	_, closer, err := app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
-	evmTx, err := indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err := indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
@@ -62,37 +62,37 @@ func Test_Reader(t *testing.T) {
 	cosmosTxHash2 := cmtTx2.Hash()
 
 	// check the tx is indexed
-	ctx, closer, err = app.CreateQueryContext(0, false)
+	_, closer, err = app.CreateQueryContext(0, false)
 	if closer != nil {
 		defer closer.Close()
 	}
 	require.NoError(t, err)
 
-	evmTx, err = indexer.TxByHash(ctx, evmTxHash)
+	evmTx, err = indexer.TxByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
-	evmTx, err = indexer.TxByHash(ctx, evmTxHash2)
+	evmTx, err = indexer.TxByHash(evmTxHash2)
 	require.NoError(t, err)
 	require.NotNil(t, evmTx)
 
 	// check the block header is indexed
-	header, err := indexer.BlockHeaderByNumber(ctx, uint64(finalizeReq.Height))
+	header, err := indexer.BlockHeaderByNumber(uint64(finalizeReq.Height))
 	require.NoError(t, err)
 	require.NotNil(t, header)
 	require.Equal(t, finalizeReq.Height, header.Number.Int64())
 
 	// check tx hash by block and index
-	txHash, err := indexer.TxHashByBlockAndIndex(ctx, uint64(finalizeReq.Height), 1)
+	txHash, err := indexer.TxHashByBlockAndIndex(uint64(finalizeReq.Height), 1)
 	require.NoError(t, err)
 	require.Equal(t, evmTxHash, txHash)
 
-	txHash, err = indexer.TxHashByBlockAndIndex(ctx, uint64(finalizeReq.Height), 2)
+	txHash, err = indexer.TxHashByBlockAndIndex(uint64(finalizeReq.Height), 2)
 	require.NoError(t, err)
 	require.Equal(t, evmTxHash2, txHash)
 
 	// iterate block txs
 	count := 0
-	err = indexer.IterateBlockTxs(ctx, uint64(finalizeReq.Height), func(tx *rpctypes.RPCTransaction) (bool, error) {
+	err = indexer.IterateBlockTxs(uint64(finalizeReq.Height), func(tx *rpctypes.RPCTransaction) (bool, error) {
 		count++
 		switch count {
 		case 1:
@@ -106,18 +106,18 @@ func Test_Reader(t *testing.T) {
 	require.Equal(t, 2, count)
 
 	// receipt by hash
-	receipt1, err := indexer.TxReceiptByHash(ctx, evmTxHash)
+	receipt1, err := indexer.TxReceiptByHash(evmTxHash)
 	require.NoError(t, err)
 	require.NotNil(t, receipt1)
 
 	// receipt by hash
-	receipt2, err := indexer.TxReceiptByHash(ctx, evmTxHash2)
+	receipt2, err := indexer.TxReceiptByHash(evmTxHash2)
 	require.NoError(t, err)
 	require.NotNil(t, receipt2)
 
 	// iterate block tx receipts
 	count = 0
-	err = indexer.IterateBlockTxReceipts(ctx, uint64(finalizeReq.Height), func(receipt *coretypes.Receipt) (bool, error) {
+	err = indexer.IterateBlockTxReceipts(uint64(finalizeReq.Height), func(receipt *coretypes.Receipt) (bool, error) {
 		count++
 		switch count {
 		case 1:
@@ -130,25 +130,25 @@ func Test_Reader(t *testing.T) {
 	require.NoError(t, err)
 
 	// block hash to number
-	blockNumber, err := indexer.BlockHashToNumber(ctx, header.Hash())
+	blockNumber, err := indexer.BlockHashToNumber(header.Hash())
 	require.NoError(t, err)
 	require.Equal(t, uint64(finalizeReq.Height), blockNumber)
 
 	// cosmos tx hash
-	hash, err := indexer.CosmosTxHashByTxHash(ctx, evmTxHash)
+	hash, err := indexer.CosmosTxHashByTxHash(evmTxHash)
 	require.NoError(t, err)
 	require.Equal(t, cosmosTxHash, hash)
 
-	hash, err = indexer.CosmosTxHashByTxHash(ctx, evmTxHash2)
+	hash, err = indexer.CosmosTxHashByTxHash(evmTxHash2)
 	require.NoError(t, err)
 	require.Equal(t, cosmosTxHash2, hash)
 
 	// tx hash by cosmos tx hash
-	txHash, err = indexer.TxHashByCosmosTxHash(ctx, cosmosTxHash)
+	txHash, err = indexer.TxHashByCosmosTxHash(cosmosTxHash)
 	require.NoError(t, err)
 	require.Equal(t, evmTxHash, txHash)
 
-	txHash, err = indexer.TxHashByCosmosTxHash(ctx, cosmosTxHash2)
+	txHash, err = indexer.TxHashByCosmosTxHash(cosmosTxHash2)
 	require.NoError(t, err)
 	require.Equal(t, evmTxHash2, txHash)
 }

--- a/indexer/snapshotter.go
+++ b/indexer/snapshotter.go
@@ -112,23 +112,22 @@ func (e *EVMIndexerImpl) RestoreExtension(height uint64, format uint32, payloadR
 func (e *EVMIndexerImpl) SnapshotExtension(height uint64, payloadWriter snapshot.ExtensionPayloadWriter) error {
 	logger := e.logger.With("module", "snapshotter")
 	var s SnapshotInfo
-	ctx := sdk.Context{}.WithContext(context.Background())
 
-	header, err := e.BlockHeaderByNumber(ctx, height)
+	header, err := e.BlockHeaderByNumber(height)
 	if err != nil {
 		logger.Error("failed to get block header", "err", err)
 		return err
 	}
 	s.Header = header
 
-	err = e.IterateBlockTxs(ctx, height, func(tx *rpctypes.RPCTransaction) (bool, error) {
-		cosmosTxHash, err := e.CosmosTxHashByTxHash(ctx, tx.Hash)
+	err = e.IterateBlockTxs(height, func(tx *rpctypes.RPCTransaction) (bool, error) {
+		cosmosTxHash, err := e.CosmosTxHashByTxHash(tx.Hash)
 		if err != nil {
 			logger.Error("failed to get cosmos tx hash", "err", err)
 			return true, err
 		}
 
-		receipt, err := e.TxReceiptByHash(ctx, tx.Hash)
+		receipt, err := e.TxReceiptByHash(tx.Hash)
 		if err != nil {
 			logger.Error("failed to get tx receipt", "err", err)
 			return true, err

--- a/jsonrpc/backend/block.go
+++ b/jsonrpc/backend/block.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (b *JSONRPCBackend) BlockNumber() (hexutil.Uint64, error) {
-	lh, err := b.app.EVMIndexer().GetLastIndexedHeight(b.ctx)
+	lh, err := b.app.EVMIndexer().GetLastIndexedHeight()
 	if err != nil {
 		return 0, err
 	}
@@ -66,7 +66,7 @@ func (b *JSONRPCBackend) GetHeaderByNumber(ethBlockNum rpc.BlockNumber) (*corety
 		return header, nil
 	}
 
-	header, err := b.app.EVMIndexer().BlockHeaderByNumber(b.ctx, blockNumber)
+	header, err := b.app.EVMIndexer().BlockHeaderByNumber(blockNumber)
 	if err != nil && errors.Is(err, collections.ErrNotFound) {
 		return nil, nil
 	} else if err != nil {
@@ -130,7 +130,7 @@ func (b *JSONRPCBackend) blockNumberByHash(hash common.Hash) (uint64, error) {
 		return number, nil
 	}
 
-	number, err := b.app.EVMIndexer().BlockHashToNumber(b.ctx, hash)
+	number, err := b.app.EVMIndexer().BlockHashToNumber(hash)
 	if err != nil {
 		b.logger.Error("failed to get block number by hash", "err", err)
 		return 0, NewInternalError("failed to get block number by hash")
@@ -203,7 +203,7 @@ func formatHeader(head *coretypes.Header) map[string]any {
 // the last indexed block height. Returns true if the block is indexed, false if not indexed or
 // if there was an error retrieving the last indexed height (error will be logged).
 func (b *JSONRPCBackend) isBlockIndexed(blockHeight uint64) (bool, error) {
-	lastIndexedHeight, err := b.app.EVMIndexer().GetLastIndexedHeight(b.ctx)
+	lastIndexedHeight, err := b.app.EVMIndexer().GetLastIndexedHeight()
 	if err != nil {
 		b.logger.Error("failed to get last indexed height", "err", err)
 		return false, err

--- a/jsonrpc/backend/cosmos.go
+++ b/jsonrpc/backend/cosmos.go
@@ -9,7 +9,7 @@ import (
 
 // CosmosTxHashByTxHash returns the Cosmos transaction hash by the Ethereum transaction hash.
 func (b *JSONRPCBackend) CosmosTxHashByTxHash(hash common.Hash) ([]byte, error) {
-	cosmosTxHash, err := b.app.EVMIndexer().CosmosTxHashByTxHash(b.ctx, hash)
+	cosmosTxHash, err := b.app.EVMIndexer().CosmosTxHashByTxHash(hash)
 	if err != nil && errors.Is(err, collections.ErrNotFound) {
 		return nil, nil
 	} else if err != nil {
@@ -22,7 +22,7 @@ func (b *JSONRPCBackend) CosmosTxHashByTxHash(hash common.Hash) ([]byte, error) 
 
 // TxHashByCosmosTxHash returns the Ethereum transaction hash by the Cosmos transaction hash.
 func (b *JSONRPCBackend) TxHashByCosmosTxHash(hash []byte) (common.Hash, error) {
-	txHash, err := b.app.EVMIndexer().TxHashByCosmosTxHash(b.ctx, hash)
+	txHash, err := b.app.EVMIndexer().TxHashByCosmosTxHash(hash)
 	if err != nil && errors.Is(err, collections.ErrNotFound) {
 		return common.Hash{}, nil
 	} else if err != nil {

--- a/jsonrpc/backend/filters.go
+++ b/jsonrpc/backend/filters.go
@@ -83,7 +83,7 @@ const (
 )
 
 func (b *JSONRPCBackend) BloomStatus() (uint64, uint64, error) {
-	sections, err := b.app.EVMIndexer().PeekBloomBitsNextSection(b.ctx)
+	sections, err := b.app.EVMIndexer().PeekBloomBitsNextSection()
 	if err != nil {
 		return 0, 0, err
 	}
@@ -112,7 +112,7 @@ func (b *JSONRPCBackend) startBloomHandlers(sectionSize uint64) {
 					task.Bitsets = make([][]byte, len(task.Sections))
 
 					for i, section := range task.Sections {
-						compVector, err := b.app.EVMIndexer().ReadBloomBits(b.ctx, section, uint32(task.Bit))
+						compVector, err := b.app.EVMIndexer().ReadBloomBits(section, uint32(task.Bit))
 						if errors.Is(err, collections.ErrNotFound) {
 							// pruned section, return empty bitset
 							task.Bitsets[i] = make([]byte, evmconfig.SectionSize/8)

--- a/jsonrpc/backend/tracer.go
+++ b/jsonrpc/backend/tracer.go
@@ -117,7 +117,7 @@ func (b *JSONRPCBackend) TraceBlockByHash(hash common.Hash, config *tracers.Trac
 
 func (b *JSONRPCBackend) TraceTransaction(hash common.Hash, config *tracers.TraceConfig) (any, error) {
 	// check if the tx is indexed
-	tx, err := b.app.EVMIndexer().TxByHash(b.ctx, hash)
+	tx, err := b.app.EVMIndexer().TxByHash(hash)
 	if err != nil {
 		return nil, err
 	} else if tx == nil {

--- a/jsonrpc/backend/tx.go
+++ b/jsonrpc/backend/tx.go
@@ -248,7 +248,7 @@ func (b *JSONRPCBackend) GetTransactionByBlockNumberAndIndex(blockNum rpc.BlockN
 		return nil, err
 	}
 
-	txhash, err := b.app.EVMIndexer().TxHashByBlockAndIndex(b.ctx, blockNumber, uint64(idx))
+	txhash, err := b.app.EVMIndexer().TxHashByBlockAndIndex(blockNumber, uint64(idx))
 	if err != nil && errors.Is(err, collections.ErrNotFound) {
 		return nil, nil
 	} else if err != nil {
@@ -363,7 +363,7 @@ func (b *JSONRPCBackend) getTransaction(hash common.Hash) (*rpctypes.RPCTransact
 		return rpcTx, nil
 	}
 
-	tx, err := b.app.EVMIndexer().TxByHash(b.ctx, hash)
+	tx, err := b.app.EVMIndexer().TxByHash(hash)
 	if err != nil && errors.Is(err, collections.ErrNotFound) {
 		return nil, nil
 	} else if err != nil {
@@ -379,7 +379,7 @@ func (b *JSONRPCBackend) getTransaction(hash common.Hash) (*rpctypes.RPCTransact
 // For newly indexed txs the value is stored directly. For old data (before this field was introduced)
 // it computes the value from all block receipts, stores all of them, and returns the result.
 func (b *JSONRPCBackend) getTxStartLogIndex(hash common.Hash, rpcTx *rpctypes.RPCTransaction) (uint, error) {
-	idx, err := b.app.EVMIndexer().TxStartLogIndexByHash(b.ctx, hash)
+	idx, err := b.app.EVMIndexer().TxStartLogIndexByHash(hash)
 	if err != nil && !errors.Is(err, collections.ErrNotFound) {
 		return 0, NewInternalError("failed to get tx start log index")
 	}
@@ -414,7 +414,7 @@ func (b *JSONRPCBackend) getTxStartLogIndex(hash common.Hash, rpcTx *rpctypes.RP
 	result := uint(0)
 	found := false
 	for i, receipt := range blockReceipts {
-		if err := b.app.EVMIndexer().StoreTxStartLogIndex(b.ctx, blockTxs[i].Hash, uint64(blockLogIndex)); err != nil {
+		if err := b.app.EVMIndexer().StoreTxStartLogIndex(blockTxs[i].Hash, uint64(blockLogIndex)); err != nil {
 			// non-fatal: log and continue; next query will recompute
 			b.logger.Error("failed to lazily store tx start log index", "hash", blockTxs[i].Hash, "err", err)
 		}
@@ -440,7 +440,7 @@ func (b *JSONRPCBackend) getReceipt(hash common.Hash) (*coretypes.Receipt, error
 		return receipt, nil
 	}
 
-	receipt, err := b.app.EVMIndexer().TxReceiptByHash(b.ctx, hash)
+	receipt, err := b.app.EVMIndexer().TxReceiptByHash(hash)
 	if err != nil && errors.Is(err, collections.ErrNotFound) {
 		return nil, nil
 	} else if err != nil {
@@ -458,7 +458,7 @@ func (b *JSONRPCBackend) getBlockTransactions(blockNumber uint64) ([]*rpctypes.R
 	}
 
 	txs := []*rpctypes.RPCTransaction{}
-	err := b.app.EVMIndexer().IterateBlockTxs(b.ctx, blockNumber, func(tx *rpctypes.RPCTransaction) (bool, error) {
+	err := b.app.EVMIndexer().IterateBlockTxs(blockNumber, func(tx *rpctypes.RPCTransaction) (bool, error) {
 		txs = append(txs, tx)
 		return false, nil
 	})
@@ -478,7 +478,7 @@ func (b *JSONRPCBackend) getBlockReceipts(blockNumber uint64) ([]*coretypes.Rece
 	}
 
 	receipt := []*coretypes.Receipt{}
-	err := b.app.EVMIndexer().IterateBlockTxReceipts(b.ctx, blockNumber, func(recept *coretypes.Receipt) (bool, error) {
+	err := b.app.EVMIndexer().IterateBlockTxReceipts(blockNumber, func(recept *coretypes.Receipt) (bool, error) {
 		receipt = append(receipt, recept)
 		return false, nil
 	})


### PR DESCRIPTION
# Description

Closes: N/A

This PR removes `context.Context` from indexer getter/setter methods that only used it for interface consistency with collection storage access.

The change keeps the public accessor API context-free while preserving the underlying storage behavior, and updates the JSON-RPC backend and indexer tests to match the new signatures.

Why this changed:
- the accessor methods did not use caller-scoped cancellation, deadlines, or request values
- keeping `context` in those APIs implied semantics that were not real
- removing it makes the indexer surface simpler and more explicit

---

## Author Checklist

I have...

- [x] included the correct type prefix in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for documenting Go code
- [ ] confirmed all CI checks have passed

## Validation

- `go test ./indexer ./jsonrpc/backend/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined context usage across the indexer and related subsystems, simplifying public APIs and internal storage calls.

* **Tests**
  * Updated test suites to match the revised indexer APIs and verify unchanged observable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->