### PR TITLE
fix(evm): clone query cosmos proto buffers

### DIFF
--- a/x/evm/precompiles/cosmos/contract.go
+++ b/x/evm/precompiles/cosmos/contract.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/gogoproto/proto"
 
 	"github.com/initia-labs/minievm/x/evm/contracts/i_cosmos"
 	"github.com/initia-labs/minievm/x/evm/types"
@@ -337,7 +338,7 @@ func (e *CosmosPrecompile) ExtendedRun(caller common.Address, input []byte, supp
 			return nil, ctx.GasMeter().GasConsumedToLimit(), types.ErrNotSupportedCosmosQuery.Wrap(queryCosmosArguments.Path)
 		}
 
-		reqData, err := types.ConvertJSONToProto(e.cdc, protoSet.Request, []byte(queryCosmosArguments.Req))
+		reqData, err := types.ConvertJSONToProto(e.cdc, proto.Clone(protoSet.Request), []byte(queryCosmosArguments.Req))
 		if err != nil {
 			return nil, ctx.GasMeter().GasConsumedToLimit(), types.ErrPrecompileFailed.Wrap(err.Error())
 		}
@@ -350,7 +351,7 @@ func (e *CosmosPrecompile) ExtendedRun(caller common.Address, input []byte, supp
 			return nil, ctx.GasMeter().GasConsumedToLimit(), types.ErrPrecompileFailed.Wrap(err.Error())
 		}
 
-		resBz, err = types.ConvertProtoToJSON(e.cdc, protoSet.Response, res.Value)
+		resBz, err = types.ConvertProtoToJSON(e.cdc, proto.Clone(protoSet.Response), res.Value)
 		if err != nil {
 			return nil, ctx.GasMeter().GasConsumedToLimit(), types.ErrPrecompileFailed.Wrap(err.Error())
 		}

--- a/x/evm/precompiles/cosmos/contract_test.go
+++ b/x/evm/precompiles/cosmos/contract_test.go
@@ -2,6 +2,8 @@ package cosmosprecompile_test
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -493,6 +495,116 @@ func Test_QueryCosmos(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, expectedRet, ret)
+}
+
+func Test_QueryCosmosDataRace(t *testing.T) {
+	ctx, cdc, ac, ak, bk := setup()
+	authorityAddr := authtypes.NewModuleAddress(govtypes.ModuleName).String()
+
+	queryPath := "/connect.oracle.v2.Query/GetPrice"
+	whitelist := types.QueryCosmosWhitelist{
+		queryPath: {
+			Request:  &oracletypes.GetPriceRequest{},
+			Response: &oracletypes.GetPriceResponse{},
+		},
+	}
+
+	const workers = 128
+	pairIDs := map[string]uint64{}
+	for i := 0; i < workers; i++ {
+		pairIDs[fmt.Sprintf("ASSET%d/USD", i)] = uint64(i + 1)
+	}
+
+	router := precompiletesting.MockGRPCRouter{
+		Routes: map[string]baseapp.GRPCQueryHandler{
+			queryPath: func(_ sdk.Context, req *abci.RequestQuery) (*abci.ResponseQuery, error) {
+				var priceReq oracletypes.GetPriceRequest
+				if err := cdc.Unmarshal(req.Data, &priceReq); err != nil {
+					return nil, err
+				}
+
+				resBz, err := cdc.Marshal(&oracletypes.GetPriceResponse{
+					Id: pairIDs[priceReq.CurrencyPair],
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				return &abci.ResponseQuery{Value: resBz}, nil
+			},
+		},
+	}
+
+	abi, err := contracts.ICosmosMetaData.GetAbi()
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var mismatches int64
+	var errs int64
+	mu := sync.Mutex{}
+	samples := []string{}
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					atomic.AddInt64(&errs, 1)
+				}
+			}()
+
+			stateDB := precompiletesting.NewMockStateDB(ctx)
+			cosmosPrecompile, err := precompiles.NewCosmosPrecompile(stateDB, cdc, ac, ak, bk, nil, router, whitelist, authorityAddr)
+			if err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+
+			pair := fmt.Sprintf("ASSET%d/USD", i)
+			inputBz, err := abi.Pack(precompiles.METHOD_QUERY_COSMOS, queryPath, fmt.Sprintf(`{"currency_pair":"%s"}`, pair))
+			if err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+
+			retBz, _, err := cosmosPrecompile.ExtendedRun(common.HexToAddress("0x1"), inputBz, precompiles.QUERY_COSMOS_GAS+uint64(len(inputBz)), true)
+			if err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+
+			unpackedRet, err := abi.Methods["query_cosmos"].Outputs.Unpack(retBz)
+			if err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+
+			var ret oracletypes.GetPriceResponse
+			if err := cdc.UnmarshalJSON([]byte(unpackedRet[0].(string)), &ret); err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+
+			want := pairIDs[pair]
+			if ret.Id != want {
+				atomic.AddInt64(&mismatches, 1)
+				mu.Lock()
+				if len(samples) < 20 {
+					samples = append(samples, fmt.Sprintf("pair=%s want=%d got=%d", pair, want, ret.Id))
+				}
+				mu.Unlock()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	t.Logf("workers=%d mismatches=%d errors=%d", workers, mismatches, errs)
+	for _, s := range samples {
+		t.Logf("CORRUPTION: %s", s)
+	}
+	require.Zero(t, errs)
+	require.Zero(t, mismatches)
 }
 
 func Test_ToDenom(t *testing.T) {


### PR DESCRIPTION
# Description

Closes: N/A

This fixes a data race in the `query_cosmos` precompile by treating whitelist protobuf messages as prototypes only. The precompile now clones request and response messages before JSON/protobuf conversion so concurrent calls do not mutate shared decode buffers.

The PR also adds concurrent regression coverage for `query_cosmos` using a shared whitelist and independent precompile instances. The test asserts zero errors and zero mismatched query results.

---

## Validation

- `go test ./x/evm/precompiles/cosmos -run 'Test_QueryCosmos$|Test_QueryCosmosDataRace' -count=1 -v`
- `go test -race ./x/evm/precompiles/cosmos -run 'Test_QueryCosmosDataRace' -count=1 -v`
- `go test ./x/evm/precompiles/cosmos -count=1`

---

## Author Checklist

I have...

- [x] included the correct type prefix in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for documenting Go code
- [ ] confirmed all CI checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data race conditions in Cosmos query handling that could cause corruption during concurrent operations.

* **Tests**
  * Added concurrent execution tests to verify data integrity and reliability of Cosmos query operations under high concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->